### PR TITLE
update with flames, xqtls, and qtl mapping modules

### DIFF
--- a/production_docker-compose.yml
+++ b/production_docker-compose.yml
@@ -817,6 +817,24 @@ services:
       - worker
       - all
 
+### flames #########################################
+  flames:
+    build:
+      context: ../scripts
+      dockerfile: flames/Dockerfile-flames
+      args:
+        PUID: ${JOB_WORKER_PUID}
+        PGID: ${JOB_WORKER_PGID}
+        
+        PGIDSCISTOR: ${JOB_WORKER_PGID_SCISTOR}
+        PGIDREF: ${JOB_WORKER_PGID_REF}
+        PGIDUSR: ${JOB_WORKER_PGID_USR}
+
+        USERNAME: ${JOB_WORKER_USERNAME}
+    profiles:
+      - worker
+      - all
+
 ### jobs_transfer #########################################
   jobs_transfer:
     build:

--- a/production_docker-compose.yml
+++ b/production_docker-compose.yml
@@ -799,6 +799,24 @@ services:
       - worker
       - all
 
+### qtls_map #########################################
+  qtls_map:
+    build:
+      context: ../scripts
+      dockerfile: qtls_map/Dockerfile-qtls_map
+      args:
+        PUID: ${JOB_WORKER_PUID}
+        PGID: ${JOB_WORKER_PGID}
+        
+        PGIDSCISTOR: ${JOB_WORKER_PGID_SCISTOR}
+        PGIDREF: ${JOB_WORKER_PGID_REF}
+        PGIDUSR: ${JOB_WORKER_PGID_USR}
+
+        USERNAME: ${JOB_WORKER_USERNAME}
+    profiles:
+      - worker
+      - all
+
 ### jobs_transfer #########################################
   jobs_transfer:
     build:

--- a/production_docker-compose.yml
+++ b/production_docker-compose.yml
@@ -781,6 +781,24 @@ services:
       - worker
       - all
 
+### xqtls #########################################
+  xqtls:
+    build:
+      context: ../scripts
+      dockerfile: xqtls/Dockerfile-xqtls
+      args:
+        PUID: ${JOB_WORKER_PUID}
+        PGID: ${JOB_WORKER_PGID}
+        
+        PGIDSCISTOR: ${JOB_WORKER_PGID_SCISTOR}
+        PGIDREF: ${JOB_WORKER_PGID_REF}
+        PGIDUSR: ${JOB_WORKER_PGID_USR}
+
+        USERNAME: ${JOB_WORKER_USERNAME}
+    profiles:
+      - worker
+      - all
+
 ### jobs_transfer #########################################
   jobs_transfer:
     build:


### PR DESCRIPTION
For FUMA version 2.0.0, add configuration for flames, xqtls analysis, and qtl mapping modules
